### PR TITLE
Include Surefire fork number in H2 file name

### DIFF
--- a/src/test/java/org/telosys/tools/commons/jdbc/ConnectionManagerTest.java
+++ b/src/test/java/org/telosys/tools/commons/jdbc/ConnectionManagerTest.java
@@ -13,9 +13,13 @@ import junit.framework.TestCase;
 
 public class ConnectionManagerTest extends TestCase {
 
+	public static String generateH2JDBCURL() {
+		return "jdbc:h2:~/test-" + System.getProperty("mavenSurefireForkNumber");
+	}
+
 	public void getH2Connection(ConnectionManager cm) throws TelosysToolsException, SQLException {
 		System.out.println("Getting connection for 'H2 in memory' ...");
-		Connection conn = cm.getConnection("org.h2.Driver", "jdbc:h2:~/test", new Properties());
+		Connection conn = cm.getConnection("org.h2.Driver", ConnectionManagerTest.generateH2JDBCURL(), new Properties());
 		assertNotNull(conn);
 		System.out.println("Connection OK.");
 		conn.close();

--- a/src/test/java/org/telosys/tools/commons/jdbc/SqlScriptRunnerTest.java
+++ b/src/test/java/org/telosys/tools/commons/jdbc/SqlScriptRunnerTest.java
@@ -20,7 +20,7 @@ public class SqlScriptRunnerTest extends TestCase {
 	private Connection getH2Connection() throws TelosysToolsException, SQLException {
 		ConnectionManager cm = new ConnectionManager();
 		System.out.println("Getting connection for 'H2 in memory' ...");
-		Connection conn = cm.getConnection("org.h2.Driver", "jdbc:h2:~/test", new Properties());
+		Connection conn = cm.getConnection("org.h2.Driver", ConnectionManagerTest.generateH2JDBCURL(), new Properties());
 		assertNotNull(conn);
 		System.out.println("Connection OK.");
 		return conn;

--- a/src/test/java/org/telosys/tools/commons/jdbc/TestH2Database.java
+++ b/src/test/java/org/telosys/tools/commons/jdbc/TestH2Database.java
@@ -84,7 +84,7 @@ public class TestH2Database {
 		classLoader.loadClass("org.h2.Driver");
 		//Class.forName("org.h2.Driver");
 		System.out.println("Driver loaded.");
-		Connection conn = DriverManager.getConnection("jdbc:h2:~/test");
+		Connection conn = DriverManager.getConnection(ConnectionManagerTest.generateH2JDBCURL());
 		System.out.println("Connection OK.");
 		conn.close();
 		System.out.println("Connection closed.");
@@ -96,8 +96,8 @@ public class TestH2Database {
 		System.out.println("Driver loaded.");
 
 		System.out.println("Getting connection...");
-		//Connection conn = DriverManager.getConnection("jdbc:h2:~/test");
-		Connection conn = driver.connect("jdbc:h2:~/test", new Properties());
+		//Connection conn = DriverManager.getConnection(ConnectionManagerTest.generateH2JDBCURL());
+		Connection conn = driver.connect(ConnectionManagerTest.generateH2JDBCURL(), new Properties());
 		
 		System.out.println("Connection OK.");
 		conn.close();


### PR DESCRIPTION
This should avoid concurrency issues when executing tests with several JVM in parallel.

This PR required https://github.com/telosys-tools-bricks/telosys-tools-parent/pull/3 to be merge.