### PR TITLE
Make sure that tests doesn't rely on specific execution order

### DIFF
--- a/src/test/java/org/telosys/tools/commons/YamlSnakeYamlTest.java
+++ b/src/test/java/org/telosys/tools/commons/YamlSnakeYamlTest.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.telosys.tools.commons.beans.Course;
 import org.telosys.tools.commons.beans.Student;
@@ -26,6 +27,11 @@ public class YamlSnakeYamlTest {
 
 	public void print(String s) {
 		System.out.println(s);
+	}
+
+	@BeforeClass
+	public static void initAll() {
+		TestsEnv.getTmpExistingFolder("/yaml");
 	}
 	
 	@Test


### PR DESCRIPTION
Currently test `testSaveBean` and `testSaveAndLoadBean` defined in `YamlSnakeYamlTest` failed if `yaml` folder doesn't exist in `target/tests-tmp`. It might exist if `YamlFileManagerTest` is executed before `YamlSnakeYamlTest` but there is no such guaranty. Adding the creation of the folder before all tests in `YamlSnakeYamlTest` avoid the issue.